### PR TITLE
Change README heading for DFHack docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-dfhack-scripts
-==============
+Lethosor's scripts
+==================
 
 A collection of DFHack scripts
 


### PR DESCRIPTION
The new build process with Sphinx can pull in other .rst format documentation, and we've got it set up to do this as of DFHack pull 697.

Changing the title makes the table of contents / link index much more meaningful for readers.  [See here for an example.](http://peridexiserrant.neocities.org/html/docs/Scripts.html#rd-party-scripts)
