### PR TITLE
In-script docs for DFHack scripts

### DIFF
--- a/adv-max-skills.lua
+++ b/adv-max-skills.lua
@@ -1,5 +1,12 @@
 -- Maximizes adventurer skills/attributes on creation
+--[[=begin
 
+adv-max-skills
+==============
+When creating an adventurer, raises all changeable skills and
+attributes to their maximum level.
+
+=end]]
 if dfhack.gui.getCurFocus() ~= 'setupadventure' then
     qerror('Must be called on adventure mode setup screen')
 end

--- a/devel/annc-monitor.lua
+++ b/devel/annc-monitor.lua
@@ -1,5 +1,17 @@
 -- Displays announcements in the DFHack console
 --@ enable = true
+--[[=begin
+
+devel/annc-monitor
+==================
+Displays announcements and reports in the console.
+
+:enable|start:      Begins monitoring
+:disable|stop:      Stops monitoring
+:interval X:        Sets the delay between checks for
+                    new announcements to ``X`` frames
+
+=end]]
 
 VERSION = '0.2'
 

--- a/devel/click-monitor.lua
+++ b/devel/click-monitor.lua
@@ -1,5 +1,15 @@
 -- Displays the mouse (grid) coordinates when the mouse is clicked
 --@ enable = true
+--[[=begin
+
+devel/click-monitor
+===================
+Displays the grid coordinates of mouse clicks in the console.
+Useful for plugin/script development.
+
+Usage: ``devel/click-monitor start|stop``
+
+=end]]
 
 VERSION = '0.2'
 

--- a/devel/modstate-monitor.lua
+++ b/devel/modstate-monitor.lua
@@ -1,5 +1,15 @@
 -- Displays changes in the key modifier state
 --@ enable = true
+--[[=begin
+
+devel/modstate-monitor
+======================
+Display changes in key modifier state, ie Ctrl/Alt/Shift.
+
+:enable|start:  Begin monitoring
+:disable|stop:  End monitoring
+
+=end]]
 
 VERSION = '0.1'
 

--- a/embark-skills.lua
+++ b/embark-skills.lua
@@ -1,4 +1,20 @@
 -- Adjusts dwarves' skills when embarking
+--[[=begin
+
+embark-skills
+=============
+Adjusts dwarves' skills when embarking.
+
+Note that already-used skill points are not taken into account or reset.
+
+:points N:      Sets the skill points remaining of the selected dwarf to ``N``.
+:points N all:  Sets the skill points remaining of all dwarves to ``N``.
+:max:           Sets all skills of the selected dwarf to "Proficient".
+:max all:       Sets all skills of all dwarves to "Proficient".
+:legendary:     Sets all skills of the selected dwarf to "Legendary".
+:legendary all: Sets all skills of all dwarves to "Legendary".
+
+=end]]
 
 VERSION = '0.1'
 

--- a/gui/extended-status.lua
+++ b/gui/extended-status.lua
@@ -1,5 +1,17 @@
 -- Adds more z-status subpages
 --@ enable = true
+--[[=begin
+
+gui/extended-status
+===================
+Adds more subpages to the ``z`` status screen.
+
+Usage::
+
+    gui/extended-status enable|disable|help|subpage_names
+    enable|disable gui/extended-status
+
+=end]]
 
 gui = require 'gui'
 dialogs = require 'gui.dialogs'

--- a/gui/load-screen.lua
+++ b/gui/load-screen.lua
@@ -1,5 +1,14 @@
 -- A replacement for the "load game" screen
 --@ enable = true
+--[[=begin
+
+gui/load-screen
+===============
+A replacement for the "continue game" screen.
+
+Usage: ``gui/load-screen enable|disable``
+
+=end]]
 
 VERSION = '0.8.2'
 

--- a/gui/settings-manager.lua
+++ b/gui/settings-manager.lua
@@ -1,9 +1,16 @@
 -- An in-game init file editor
---[[
-Sample usage:
+--[[=begin
+
+gui/settings-manager
+====================
+An in-game settings manager (init.txt/d_init.txt)
+
+Recommended for use as a keybinding::
+
     keybinding add Alt-S@title settings-manager
     keybinding add Alt-S@dwarfmode/Default settings-manager
-]]
+
+=end]]
 
 VERSION = '0.6.0'
 

--- a/modtools/raw-lint.lua
+++ b/modtools/raw-lint.lua
@@ -1,5 +1,12 @@
 -- Check for common mistakes in raw files
 --@ enable = true
+--[[=begin
+
+modtools/raw-lint
+=================
+Checks for simple issues with raw files. Can be run automatically.
+
+=end]]
 
 utils = require 'utils'
 

--- a/open-legends.lua
+++ b/open-legends.lua
@@ -1,5 +1,13 @@
 -- open legends screen when in fortress mode
 --@ module = true
+--[[=begin
+
+open-legends
+============
+Open a legends screen when in fortress mode.
+Compatible with `export-legends`.
+
+=end]]
 
 gui = require 'gui'
 utils = require 'utils'

--- a/troubleshoot-item.lua
+++ b/troubleshoot-item.lua
@@ -1,5 +1,12 @@
--- troubleshoot_item.lua
+-- troubleshoot-item.lua
 --@ module = true
+--[[=begin
+
+troubleshoot-item
+=================
+Print various properties of the selected item.
+
+=end]]
 
 function find_specific_ref(object, type)
     for i, ref in pairs(object.specific_refs) do


### PR DESCRIPTION
Simple copy-paste, with edits to match the required header level and DFHack argument style.

I tried avoiding duplication by `.. include`ing the docs back to the readme, but Github has disabled that feature of rst due to security concerns :(

This completes the 3rdparty docs for DFHack/dfhack#713, once the submodules are updated.
